### PR TITLE
build-dpkg: only mv artifacts that exist

### DIFF
--- a/build-dpkg/build.sh
+++ b/build-dpkg/build.sh
@@ -19,4 +19,6 @@ dpkg-buildpackage $@
 
 ## Move the built artifacts into the Docker mounted workspace
 mkdir -p artifacts
-mv ../*.deb ../*.changes ../*.dsc ../*.buildinfo ../*.tar.gz ./artifacts
+for a in ../*.deb ../*.changes ../*.dsc ../*.buildinfo ../*.ddeb ../*.tar.gz; do
+    [ -f "${a}" ] && mv "${a}" ./artifacts/
+done


### PR DESCRIPTION
Use more expansive wildcards but do this in a loop with a predicate that
tests if the files exist and only move them if they do. This prevents
the case where some of the files don't exist. For example, in the Xenial
case the *.buildinfo files aren't generated.