### PR TITLE
Add artifact upload to tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Artifacts
         uses: actions/upload-artifact@v3
         with:
-          files: |
+          path: |
             adaptit/artifacts/*.dsc
             adaptit/artifacts/*.deb
             adaptit/artifacts/*.changes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,4 +46,12 @@ jobs:
           echo "Doing package build"
           docker run --rm -v $(pwd):/github/workspace --workdir /github/workspace/adaptit -e LOCAL=${{ matrix.release }} build-dpkg:${{ matrix.release }} /build.sh -I.git -Iwin32_utils ${{ matrix.args }}
 
-
+      - name: Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          files: |
+            adaptit/artifacts/*.dsc
+            adaptit/artifacts/*.deb
+            adaptit/artifacts/*.changes
+            adaptit/artifacts/*.buildinfo
+            adaptit/artifacts/*.ddeb


### PR DESCRIPTION
This will upload all the generated files as a single artifact associated with the workflow run. The artifact zip is 200 MB for each test run. I don't think this counts towards the 500MB Packages limit that github has for public projects. But it's possible the 200MB size may cause issues in the future. We can also set a low number of days for retention of the artifact files.